### PR TITLE
Initialize `halted` field of CPU to correct 0 value.

### DIFF
--- a/i8080.c
+++ b/i8080.c
@@ -746,6 +746,7 @@ void i8080_init(i8080* const c) {
     c->interrupt_pending = 0;
     c->interrupt_vector = 0;
     c->interrupt_delay = 0;
+    c->halted = 0;
 
     c->userdata = NULL;
     c->read_byte = NULL;


### PR DESCRIPTION
Otherwise, its initial value is undefined, and can in fact be non-0.